### PR TITLE
WSCPE: Fix `AnalizarCPE`

### DIFF
--- a/wscpe.py
+++ b/wscpe.py
@@ -549,11 +549,12 @@ class WSCPE(BaseWS):
         self.FechaInicioEstado = cab.get("fechaInicioEstado")
         self.FechaVencimiento = cab.get("fechaVencimiento")
         self.PDF = ret.get("pdf")  # base64
-        cpe_bytes = self.PDF
-        if isinstance(cpe_bytes, string_types):
-            cpe_bytes = cpe_bytes.encode("utf-8")
-        with open(archivo, "wb") as fh:
-            fh.write(cpe_bytes)
+        if self.PDF is not None:
+            cpe_bytes = self.PDF
+            if isinstance(cpe_bytes, string_types):
+                cpe_bytes = cpe_bytes.encode("utf-8")
+            with open(archivo, "wb") as fh:
+                fh.write(cpe_bytes)
 
     @inicializar_y_capturar_excepciones
     def AnularCPE(self, archivo="cpe.pdf"):


### PR DESCRIPTION
## Summary

The method `AnularCPE` no longer returns the pdf field

## Checklist

- [x] Classes, Variables, function and methods logic  ok
- [x] Comments written explaining what the code does
- [x] All python code is PEP8 compliant (run black .)
- [x] No lint issues (run flake8)
~~- [ ] Test coverage with pytest implemented~~
- [x] Reviewers assigned (at least 1 mentor)

## Test evidence

```
error en test de `AnularCPE`

=================================== FAILURES ===================================
_______________________________ test_anular_cpe ________________________________

auth = <pyafipws.wscpe.WSCPE object at 0x7f567267d3d0>

    def test_anular_cpe(auth):
        wscpe = auth
        wscpe.AgregarCabecera(tipo_cpe=74, sucursal=221, nro_orden=49)
>       wscpe.AnularCPE()

tests/test_wscpe.py:243: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../ve/lib/python3.8/site-packages/PyAfipWs-3.8.b_2641_-py3.8.egg/pyafipws/utils.py:201: in capturar_errores_wrapper
    return func(self, *args, **kwargs)
../ve/lib/python3.8/site-packages/PyAfipWs-3.8.b_2641_-py3.8.egg/pyafipws/wscpe.py:574: in AnularCPE
    self.AnalizarCPE(ret, archivo)
../ve/lib/python3.8/site-packages/PyAfipWs-3.8.b_2641_-py3.8.egg/pyafipws/utils.py:201: in capturar_errores_wrapper
    return func(self, *args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pyafipws.wscpe.WSCPE object at 0x7f567267d3d0>
ret = {'cabecera': {'estado': 'AN', 'fechaEmision': datetime.datetime(2021, 11, 27, 12, 58, 5), 'fechaInicioEstado': datetim...5), ...}, 'errores': [], 'metadata': {'fechaHora': datetime.datetime(2021, 11, 27, 12, 58, 47), 'servidor': 'vivaldi'}}
archivo = 'cpe.pdf'

    @inicializar_y_capturar_excepciones
    def AnalizarCPE(self, ret, archivo="cpe.pdf"):
        "Extrae los resultados de autorización de una carta porte automotor."
        cab = ret.get("cabecera")
        self.NroCTG = cab.get("nroCTG")
        self.FechaEmision = cab.get("fechaEmision")
        self.Estado = cab.get("estado")
        self.FechaInicioEstado = cab.get("fechaInicioEstado")
        self.FechaVencimiento = cab.get("fechaVencimiento")
        self.PDF = ret.get("pdf")  # base64
        cpe_bytes = self.PDF
        if isinstance(cpe_bytes, string_types):
            cpe_bytes = cpe_bytes.encode("utf-8")
        with open(archivo, "wb") as fh:
>           fh.write(cpe_bytes)
E           TypeError: a bytes-like object is required, not 'NoneType'

../ve/lib/python3.8/site-packages/PyAfipWs-3.8.b_2641_-py3.8.egg/pyafipws/wscpe.py:557: TypeError
```