### PR TITLE
Makefile command update for manual testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ get-auth:
 	curl -o reingart.zip https://www.sistemasagiles.com.ar/soft/pyafipws/reingart.zip
 	python -m zipfile -e reingart.zip .
 
-sample-invoice:
+access-ticket:
 	python -m pyafipws.wsaa
 
-sign-cert:
+sample-invoice:
 	python -m pyafipws.wsfev1 --prueba
 
 # Use "git clean -n" to see the files to be cleaned

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,22 @@ test:
 	.venv/bin/py.test tests
 
 clean:
-	rm -Rf .venv 
+	rm -Rf .venv
+
+# Works with bash and linux
+load-tests:
+	cp conf/*.ini .
+	curl -o reingart.zip https://www.sistemasagiles.com.ar/soft/pyafipws/reingart.zip
+	python -m zipfile -e reingart.zip .
+
+sign-tra:
+	python -m pyafipws.wsaa
+
+sign-cert:
+	python -m pyafipws.wsfev1 --prueba
+
+# Use "git clean -n" to see the files to be cleaned
+# Use only when only the config files are untracked
+# Finally use "git clean -f" to remove untracked files(in this case test files)
 
 .PHONY: install test

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,16 @@ clean:
 	rm -Rf .venv
 
 # Works with bash and linux
-load-tests:
+# This command first copies all the configuration settings from the conf folder
+# to the main folder and next it downloads test key and digital certificate that 
+# that can be used for testing and lastly the python module is used to decompress
+# the files
+get-auth:
 	cp conf/*.ini .
 	curl -o reingart.zip https://www.sistemasagiles.com.ar/soft/pyafipws/reingart.zip
 	python -m zipfile -e reingart.zip .
 
-sign-tra:
+sample-invoice:
 	python -m pyafipws.wsaa
 
 sign-cert:
@@ -29,5 +33,11 @@ sign-cert:
 # Use "git clean -n" to see the files to be cleaned
 # Use only when only the config files are untracked
 # Finally use "git clean -f" to remove untracked files(in this case test files)
+# This command will list all the files that are untracked. You can clean them verbosely
+# using git clean -i. Else, if you are sure, you can se -f to remove all untracked files
+# without a prompt
+clean-test:
+	git clean -n
+	git clean -i
 
-.PHONY: install test
+.PHONY: install test get-auth sample-invoice sign-cert


### PR DESCRIPTION
## Summary
My experience with testing pyafipws from the command line was a bit repetitive. So I decided to use a bunch of useful make commands that will reduce the workload of typing the commands over and over again. This PR solves the issue of repeatedly typing the same commands when running manual tests 

## Checklist

- [x] Classes, Variables, function and methods logic  ok