### PR TITLE
Fix 32bit workflow failing in the Github Actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2
 dbf>=0.88.019
-Pillow<=9.5.0; 
+Pillow<=9.5.0; platform_machine!='x86_64'
 Pillow>=2.0.0; platform_machine!='x86_64'
 tabulate==0.8.5
 certifi>=2020.4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2
 dbf>=0.88.019
-Pillow>=2.0.0
+Pillow<=9.5.0; 
+Pillow>=2.0.0; platform_machine!='x86_64'
 tabulate==0.8.5
 certifi>=2020.4.5.1
 qrcode==6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2
 dbf>=0.88.019
 Pillow<=9.5.0; platform_machine!='x86_64'
-Pillow>=2.0.0; platform_machine!='x86_64'
+Pillow>=2.0.0; platform_machine=='x86_64'
 tabulate==0.8.5
 certifi>=2020.4.5.1
 qrcode==6.1


### PR DESCRIPTION
## Summary

This PR aims to fix the build failures in the GitHub actions workflow for Windows 32-bit systems
The cause of this build failure was due to Pillow v9.5.0 having its last support for 32-bit systems and in the requirements.txt file, a version higher than v9.5.0 was being installed therefore causing the 32bit workflow to fail


## Checklist
- [x] No lint issues (run flake8)
