### PR TITLE
Create pyafipws installers and deploy as releases

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -73,6 +73,12 @@ jobs:
         name: dist-${{ matrix.targetplatform }}
         path: |
           dist/
+    - name: Deploy PyAfipWs Installer
+      uses: actions/upload-artifact@v3
+      with:
+        name: PyAfipWs-Installer-${{ matrix.targetplatform }}
+        path: |
+          **/PyAfipWs-*-full.exe
 
   test:
     name: "Full End-2-End test"

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -60,6 +60,17 @@ jobs:
       run: |
         mkdir .\dist\tests
         copy .\tests\powershell\*.* .\dist\tests
+    - name: Download Visual Studio Redistributable (32bits)
+      if: matrix.targetplatform == 'x86'
+      run: |
+        curl -L https://aka.ms/vs/17/release/vc_redist.x86.exe -o vcredist.exe
+    - name: Download Visual Studio 22 Redistributable (64bits)
+      if: matrix.targetplatform != 'x86'
+      run: |
+        curl -L https://aka.ms/vs/17/release/vc_redist.x64.exe -o vcredist.exe
+    - name: Copy Visual Studio Redistributable
+      run: |
+        copy vcredist.exe .\dist\
     - name: Save repository metadata for release env-vars
       run: |
         echo release_version="${{ matrix.python-version }}".$(git rev-list --count --all) > dist/.env

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -44,6 +44,14 @@ jobs:
     - name: Build executables
       run: |
         python setup_win.py py2exe
+    - name: Install NSIS for building Installers
+      run: |
+        curl -L https://sourceforge.net/projects/nsis/files/latest/download -o NSISInstaller.exe
+        Start-Process -FilePath "NSISInstaller.exe" -ArgumentList "/S" -Wait
+        del "NSISInstaller.exe"
+    - name: Build PyAfipWs Installer
+      run: |
+        makensis.exe base.nsi
     - name: Remove uneeded libs (TK)
       run: |
         Remove-Item .\dist\lib\tcl -recurse

--- a/nsis.py
+++ b/nsis.py
@@ -172,10 +172,10 @@ install_vcredist = r"""
     StrCmp $0 "Microsoft Visual C++ 2008 Redistributable - x86 9.0.21022"  vcredist_ok vcredist_install
  
     vcredist_install:
-    File "vcredist_x86.exe" 	
+    File "vcredist.exe"
     DetailPrint "Installing Microsoft Visual C++ 2008 Redistributable"
-    ExecWait '"$INSTDIR\vcredist_x86.exe" /q' $0
-    Delete $INSTDIR\vcredist_x86.exe
+    ExecWait '"$INSTDIR\vcredist.exe" /q' $0
+    Delete $INSTDIR\vcredist.exe
     vcredist_ok:
     
 """


### PR DESCRIPTION
## Summary

This pull request aims to solve issue #109 and provide a GitHub action that will run every time there is a push on the main branch and generate a one-file installer and also make push a release containing the recent one-file installer 

Initially, the workflow did not generate the exe file required, but it can now as it was missing a crucial file(vcredit_x86.exe). This has been tested locally. Currently the workflow deploys the installer as a release artifact

## Checklist

- [x] Classes, Variables, function and methods logic  ok

## Manual test evidence

Evidence of the generated exe file
![image](https://github.com/PyAr/pyafipws/assets/64011386/3747169b-b5ea-45df-850a-0cdccab49627)
