### PR TITLE
Solution to issue #133 when building for 32bit and 64bit

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -29,6 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
         python -m pip install --upgrade cachetools pefile
+    - name: Change requirements.txt on 32bit python
+      if: matrix.targetplatform == 'x86'
+      run: |
+        python -c "with open('requirements.txt', 'r') as file: content = file.read(); content = content.replace('Pillow>=2.0.0', 'Pillow<=9.5.0'); f = open('requirements.txt', 'w'); f.write(content)"
     - name: Install production dependencies
       run: |
         pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,9 @@ pysimplesoap==1.08.14; python_version <= '2.7'
 git+https://github.com/pysimplesoap/pysimplesoap.git@py311#pysimplesoap; python_version > '3'
 cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
+Pillow>=2.0.0
 fpdf>=1.7.2
 dbf>=0.88.019
-Pillow<=9.5.0; platform_machine!='x86_64'
-Pillow>=2.0.0; platform_machine=='x86_64'
 tabulate==0.8.5
 certifi>=2020.4.5.1
 qrcode==6.1


### PR DESCRIPTION
## Summary
This PR solves the issue #133 when installing pillow on 64bit systems
After much research, it seems it's not possible to specify the Python version type directly 

What we specify in the GH yaml file is not the OS type but rather the python type. So we are running both 32bit and 64bit python versions on a 64bit processor(or GH runner). 

```yaml
runs-on: windows-latest
    strategy:
      fail-fast: false
      matrix:
        python-version: ["3.10"]
        targetplatform: [x86, x64]

    steps:
    - uses: actions/checkout@v2
      with:
        fetch-depth: 0
    - name: Set up Python ${{ matrix.python-version }}
      uses: actions/setup-python@v2
      with:
        python-version: ${{ matrix.python-version }}
        architecture : ${{ matrix.targetplatform }}
```
Based on their [GH action documentation on runners](https://github.com/marketplace/actions/cross-platform-action#architectures), all runners run on 64bit systems. 

A Walkaround is to set the requirements.txt always to use the latest version of Pillow and then change the requirements.txt file before installing the requirements on windows 32bit Python versions so it compiles successfully for 32bit builds while using the latest version for 64bit

```yaml
- name: Change requirements.txt on 32bit python
      if: matrix.targetplatform == 'x86'
      run: |
        python -c "with open('requirements.txt', 'r') as file: content = file.read(); content = content.replace('Pillow>=2.0.0', 'Pillow<=9.5.0'); f = open('requirements.txt', 'w'); f.write(content)"
```

**MANUAL TEST EVIDENCE**

Pillow Installed on 32bit python don't exceed v9.5.0
![image](https://github.com/PyAr/pyafipws/assets/64011386/9c81766f-0be7-4aca-a4b3-98e847553775)

while Pillow on 64bit use the latest versions
![image](https://github.com/PyAr/pyafipws/assets/64011386/3bc386c1-e1cc-426c-9d5f-465b8fb0e19f)

all this while ensuring the normal python 3+ tests are running

## Checklist

- [x] Classes, Variables, function and methods logic  ok