### PR TITLE
Deploy installers to release section

### DIFF
--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -161,6 +161,16 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
+      - name: Download 64Bit Installer
+        uses: actions/download-artifact@v3
+        with:
+          name: PyAfipWs-Installer-x64
+          path: PyAfipWs-Installer-x64.exe
+      - name: Download 32bit Installer
+        uses: actions/download-artifact@v3
+        with:
+          name: PyAfipWs-Installer-x86
+          path: PyAfipWs-Installer-x86.exe
       - name: Download distribution binaries
         uses: actions/download-artifact@v3
         with:
@@ -188,5 +198,7 @@ jobs:
           prerelease: ${{ (github.ref != 'main') }}
           title: "Dev Build ${{ env.release_version }} ${{ env.git_branch }} @ ${{ env.git_short_hash }}"
           files: |
+            PyAfipWs-Installer-x64.exe
+            PyAfipWs-Installer-x86.exe
             dist-32.zip
             dist-64.zip


### PR DESCRIPTION
## Summary
This PR aims to close the issue on #109 and the PR merged #131. This PR adds the functionality of deploying PyAfipWs Installers to the release section, both the 32bit and 64bit versions

## Checklist

- [x] Classes, Variables, function and methods logic  ok

## Manual test evidence

Here is a screenshot from my tested branch on my forked repo of the release 
![image](https://github.com/PyAr/pyafipws/assets/64011386/8abf1064-175b-476b-91d3-369f59b8400d)