### PR TITLE
removed old pysimplesoap dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 httplib2==0.9.2; python_version <= '2.7'
 httplib2==0.20.4; python_version > '3'
 pysimplesoap==1.08.14; python_version <= '2.7'
-git+https://github.com/pysimplesoap/pysimplesoap.git@py311#pysimplesoap; python_version > '3'
+pysimplesoap==1.10 python_version > '3'
 cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 httplib2==0.9.2; python_version <= '2.7'
 httplib2==0.20.4; python_version > '3'
 pysimplesoap==1.08.14; python_version <= '2.7'
-pysimplesoap==1.10 python_version > '3'
+pysimplesoap==1.10; python_version > '3'
 cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2


### PR DESCRIPTION
## Summary
This PR aims to remove the classic use of a specific github branch version of pysimplesoap and revert to the regular default version

## Checklist

- [x] Classes, Variables, function and methods logic  ok
## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
