### PR TITLE
Use the README file as the docs on PYPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,30 +42,18 @@ kwargs["packages"] = ["pyafipws", "pyafipws.formatos"]
 opts = {}
 data_files = [("pyafipws/plantillas", glob.glob("plantillas/*"))]
 
-
-long_desc = (
-    "Interfases, herramientas y aplicativos para Servicios Web"
-    "AFIP (Factura Electrónica, Granos, Aduana, etc.), "
-    "ANMAT (Trazabilidad de Medicamentos), "
-    "RENPRE (Trazabilidad de Precursores Químicos), "
-    "ARBA (Remito Electrónico)"
-)
-
 # convert the README and format in restructured text (only when registering)
-if "sdist" in sys.argv and os.path.exists("README.md") and sys.platform == "linux2":
-    try:
-        cmd = ["pandoc", "--from=markdown", "--to=rst", "README.md"]
-        long_desc = subprocess.check_output(cmd).decode("utf8")
-        open("README.rst", "w").write(long_desc.encode("utf8"))
-    except Exception as e:
-        warnings.warn("Exception when converting the README format: %s" % e)
-
+# from docs https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
+from pathlib import Path
+parent_dir = Path(__file__).parent
+long_desc = (parent_dir / "README.md").read_text()
 
 setup(
     name="PyAfipWs",
     version=__version__,
     description=desc,
     long_description=long_desc,
+    long_description_content_type="text/markdown",
     author="Mariano Reingart",
     author_email="reingart@gmail.com",
     url="https://github.com/reingart/pyafipws",

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,8 @@ data_files = [("pyafipws/plantillas", glob.glob("plantillas/*"))]
 
 # convert the README and format in restructured text (only when registering)
 # from docs https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/
-from pathlib import Path
-parent_dir = Path(__file__).parent
-long_desc = (parent_dir / "README.md").read_text()
+parent_dir = os.getcwd()
+long_desc = open(os.path.join(parent_dir, "README.md")).read()
 
 setup(
     name="PyAfipWs",


### PR DESCRIPTION
## Summary
This PR aims to provide a means for pyafipws to use the README.md file to be used as it's documentation when deployed to pypi. 
## Checklist

- [x] Classes, Variables, function and methods logic  ok
- [x] Comments written explaining what the code does
- [x] All python code is PEP8 compliant (run black .)
- [x] No lint issues (run flake8)


## Manual test evidence
Here is evidence from twine when checking the packages in the dist/* folder

![image](https://github.com/PyAr/pyafipws/assets/64011386/0774f612-6ee1-48bf-8098-d99a18b9cda6)

![image](https://github.com/PyAr/pyafipws/assets/64011386/df2934d8-50d5-4aeb-932c-fa030a99b985)

![image](https://github.com/PyAr/pyafipws/assets/64011386/a86da112-4e95-4484-92e1-ff233e988e20)


