### PR TITLE
Bump: pysimplesoap git link -> 1.8.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 httplib2==0.9.2; python_version <= '2.7'
 httplib2==0.20.4; python_version > '3'
 pysimplesoap==1.08.14; python_version <= '2.7'
-git+https://github.com/pysimplesoap/pysimplesoap.git@py311#pysimplesoap; python_version > '3'
+pysimplesoap==1.8.22; python_version > '3'
 cryptography==3.3.2; python_version <= '2.7'
 cryptography==41.0.1; python_version > '3'
 fpdf>=1.7.2

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "httplib2==0.9.2;python_version <= '2.7'",
         "httplib2>=0.20.4;python_version > '3'",
         "pysimplesoap==1.08.14;python_version <= '2.7'",
+        "pysimplesoap==1.8.22;python_version > '3'"
         "cryptography==3.3.2;python_version <= '2.7'",
         "cryptography>=3.4.7;python_version > '3'",
         "fpdf>=1.7.2",
@@ -70,9 +71,6 @@ setup(
         "certifi>=2020.4.5.1",
         "qrcode>=6.1",
         "future>=0.18.2",
-    ],
-    dependency_links=[
-        "git+https://github.com/pysimplesoap/pysimplesoap.git@py311#pysimplesoap; python_version > '3'",
     ],
     extras_require={
         "opt": ["pywin32==304;sys_platform == 'win32' and python_version > '3'"]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "httplib2==0.9.2;python_version <= '2.7'",
         "httplib2>=0.20.4;python_version > '3'",
         "pysimplesoap==1.08.14;python_version <= '2.7'",
-        "pysimplesoap==1.8.22;python_version > '3'"
+        "pysimplesoap==1.8.22;python_version > '3'",
         "cryptography==3.3.2;python_version <= '2.7'",
         "cryptography>=3.4.7;python_version > '3'",
         "fpdf>=1.7.2",


### PR DESCRIPTION
## Summary
This PR aims to upgrade pysimplesoap to a specific version for python3

## Checklist

- [x] Classes, Variables, function and methods logic  ok
- [x] Comments written explaining what the code does
- [x] All python code is PEP8 compliant (run black .)

## Manual test evidence

(attach command-line examples, execution output & logs, etc.)
